### PR TITLE
Fix cross compilation errors

### DIFF
--- a/core/src/main/scala/zio/metrics/connectors/newrelic/package.scala
+++ b/core/src/main/scala/zio/metrics/connectors/newrelic/package.scala
@@ -6,12 +6,14 @@ import zio.metrics.connectors.internal.MetricsClient
 
 package object newrelic {
 
-  lazy val newRelicLayer: ZLayer[MetricsConfig & NewRelicConfig, Nothing, Unit] =
-    ZLayer.makeSome[MetricsConfig & NewRelicConfig, Unit](
-      make,
-      Client.default.orDie,
-      Scope.default,
-    )
+  lazy val newRelicLayer: ZLayer[MetricsConfig & NewRelicConfig, Nothing, Unit] = {
+    val metricsConfig  = ZLayer.service[MetricsConfig]
+    val newRelicConfig = ZLayer.service[NewRelicConfig]
+    val client         = Client.default.orDie
+    val scope          = Scope.default
+
+    metricsConfig ++ newRelicConfig ++ (scope >>> client) >>> make
+  }
 
   private lazy val make: URLayer[MetricsConfig & NewRelicConfig & Client, Unit] = ZLayer(for {
     encoder <- newRelicEncoder

--- a/micrometer/src/main/scala/zio/metrics/connectors/micrometer/MicroMeterConfig.scala
+++ b/micrometer/src/main/scala/zio/metrics/connectors/micrometer/MicroMeterConfig.scala
@@ -1,6 +1,0 @@
-package zio.metrics.connectors.micrometer
-
-final case class MicroMeterConfig(summaryPercentileDigitsOfPrecision: Int)
-object MicroMeterConfig {
-  val default: MicroMeterConfig = MicroMeterConfig(3)
-}

--- a/micrometer/src/main/scala/zio/metrics/connectors/micrometer/MicroMeterConfig.scala
+++ b/micrometer/src/main/scala/zio/metrics/connectors/micrometer/MicroMeterConfig.scala
@@ -1,0 +1,6 @@
+package zio.metrics.connectors.micrometer
+
+final case class MicroMeterConfig(summaryPercentileDigitsOfPrecision: Int)
+object MicroMeterConfig {
+  val default: MicroMeterConfig = MicroMeterConfig(3)
+}

--- a/micrometer/src/main/scala/zio/metrics/connectors/micrometer/MicrometerConfig.scala
+++ b/micrometer/src/main/scala/zio/metrics/connectors/micrometer/MicrometerConfig.scala
@@ -1,0 +1,6 @@
+package zio.metrics.connectors.micrometer
+
+final case class MicrometerConfig(summaryPercentileDigitsOfPrecision: Int)
+object MicrometerConfig {
+  val default: MicrometerConfig = MicrometerConfig(summaryPercentileDigitsOfPrecision = 3)
+}

--- a/micrometer/src/main/scala/zio/metrics/connectors/micrometer/MicrometerMetricListener.scala
+++ b/micrometer/src/main/scala/zio/metrics/connectors/micrometer/MicrometerMetricListener.scala
@@ -1,34 +1,33 @@
 package zio.metrics.connectors.micrometer
 
-import java.lang.{Double => JDouble}
 import java.time.Instant
-import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.{ConcurrentHashMap, ConcurrentMap}
 
-import scala.jdk.CollectionConverters.IterableHasAsJava
+import scala.jdk.CollectionConverters._
 
-import zio.{Unsafe, ZIO}
+import zio.{Unsafe, URIO, ZIO}
 import zio.metrics.{MetricKey, MetricKeyType, MetricListener}
 import zio.metrics.MetricKeyType.{Counter, Frequency, Gauge}
+import zio.metrics.connectors.micrometer.internal.AtomicDouble
 
 import io.micrometer.core.instrument.{DistributionSummary, MeterRegistry, Tag}
 
-private[micrometer] class MicrometerMetricListener(meterRegistry: MeterRegistry) extends MetricListener {
-  private lazy val gauges: ConcurrentHashMap[MetricKey[Gauge], AtomicDouble] =
-    new ConcurrentHashMap[MetricKey[Gauge], AtomicDouble]()
-
+private[micrometer] class MicrometerMetricListener(
+  meterRegistry: MeterRegistry,
+  config: MicroMeterConfig,
+  activeGauges: ConcurrentMap[MetricKey.Gauge, AtomicDouble])
+    extends MetricListener {
   private def getOrCreateGaugeRef(key: MetricKey[Gauge]): AtomicDouble =
-    gauges
-      .computeIfAbsent(
-        key,
-        _ =>
-          meterRegistry.gauge(
-            key.name,
-            micrometerTags(key.tags).asJava,
-            AtomicDouble.make(0),
-            (v: AtomicDouble) => v.get(),
-          ),
-      )
+    activeGauges.computeIfAbsent(
+      key,
+      _ =>
+        meterRegistry.gauge(
+          key.name,
+          micrometerTags(key.tags).asJava,
+          AtomicDouble.make(0),
+          (v: AtomicDouble) => v.get(),
+        ),
+    )
 
   override def updateHistogram(
     key: MetricKey[MetricKeyType.Histogram],
@@ -70,7 +69,7 @@ private[micrometer] class MicrometerMetricListener(meterRegistry: MeterRegistry)
       .distributionStatisticBufferLength(key.keyType.maxSize)
       .distributionStatisticExpiry(key.keyType.maxAge)
       .publishPercentiles(key.keyType.quantiles: _*)
-      .percentilePrecision(3) // should this be added to config?
+      .percentilePrecision(config.summaryPercentileDigitsOfPrecision)
       .register(meterRegistry)
       .record(value)
 
@@ -78,52 +77,13 @@ private[micrometer] class MicrometerMetricListener(meterRegistry: MeterRegistry)
     meterRegistry
       .counter(key.name, micrometerTags(key.tags).asJava)
       .increment(value)
-
-  /**
-   * Scala's `Double` implementation does not play nicely with Java's
-   * `AtomicReference.compareAndSwap` as `compareAndSwap` uses Java's `==`
-   * reference equality when it performs an equality check. This means that even
-   * if two Scala `Double`s have the same value, they will still fail
-   * `compareAndSwap` as they will most likely be two, distinct object
-   * references. Thus, `compareAndSwap` will fail.
-   *
-   * This `AtomicDouble` implementation is a workaround for this issue that is
-   * backed by an `AtomicLong` instead of an `AtomicReference` in which the
-   * Double's bits are stored as a Long value. This approach also reduces boxing
-   * and unboxing overhead that can be incurred with `AtomicReference`.
-   */
-  final private class AtomicDouble private (private val ref: AtomicLong) {
-
-    def get(): Double =
-      JDouble.longBitsToDouble(ref.get())
-
-    def set(newValue: Double): Unit =
-      ref.set(JDouble.doubleToLongBits(newValue))
-
-    def compareAndSet(expected: Double, newValue: Double): Boolean =
-      ref.compareAndSet(JDouble.doubleToLongBits(expected), JDouble.doubleToLongBits(newValue))
-
-    def incrementBy(value: Double): Unit = {
-      var loop = true
-
-      while (loop) {
-        val current = get()
-        loop = !compareAndSet(current, current + value)
-      }
-    }
-  }
-
-  private object AtomicDouble {
-
-    def make(value: Double): AtomicDouble =
-      new AtomicDouble(new AtomicLong(JDouble.doubleToLongBits(value)))
-  }
-
 }
 
 object MicrometerMetricListener {
-
-  private[micrometer] def make: ZIO[MeterRegistry, Nothing, MicrometerMetricListener] =
-    ZIO.serviceWith[MeterRegistry](new MicrometerMetricListener(_))
-
+  private[micrometer] def make: URIO[MeterRegistry with MicroMeterConfig, MicrometerMetricListener] =
+    for {
+      meterRegistry <- ZIO.service[MeterRegistry]
+      config        <- ZIO.service[MicroMeterConfig]
+      activeGauges  <- ZIO.succeed(new ConcurrentHashMap[MetricKey.Gauge, AtomicDouble])
+    } yield new MicrometerMetricListener(meterRegistry, config, activeGauges)
 }

--- a/micrometer/src/main/scala/zio/metrics/connectors/micrometer/MicrometerMetricListener.scala
+++ b/micrometer/src/main/scala/zio/metrics/connectors/micrometer/MicrometerMetricListener.scala
@@ -13,9 +13,9 @@ import zio.metrics.connectors.micrometer.internal.AtomicDouble
 import io.micrometer.core.instrument.{DistributionSummary, MeterRegistry, Tag}
 
 private[micrometer] class MicrometerMetricListener(
-  meterRegistry: MeterRegistry,
-  config: MicroMeterConfig,
-  activeGauges: ConcurrentMap[MetricKey.Gauge, AtomicDouble])
+                                                    meterRegistry: MeterRegistry,
+                                                    config: MicrometerConfig,
+                                                    activeGauges: ConcurrentMap[MetricKey.Gauge, AtomicDouble])
     extends MetricListener {
   private def getOrCreateGaugeRef(key: MetricKey[Gauge]): AtomicDouble =
     activeGauges.computeIfAbsent(
@@ -80,10 +80,10 @@ private[micrometer] class MicrometerMetricListener(
 }
 
 object MicrometerMetricListener {
-  private[micrometer] def make: URIO[MeterRegistry with MicroMeterConfig, MicrometerMetricListener] =
+  private[micrometer] def make: URIO[MeterRegistry with MicrometerConfig, MicrometerMetricListener] =
     for {
       meterRegistry <- ZIO.service[MeterRegistry]
-      config        <- ZIO.service[MicroMeterConfig]
+      config        <- ZIO.service[MicrometerConfig]
       activeGauges  <- ZIO.succeed(new ConcurrentHashMap[MetricKey.Gauge, AtomicDouble])
     } yield new MicrometerMetricListener(meterRegistry, config, activeGauges)
 }

--- a/micrometer/src/main/scala/zio/metrics/connectors/micrometer/internal/AtomicDouble.scala
+++ b/micrometer/src/main/scala/zio/metrics/connectors/micrometer/internal/AtomicDouble.scala
@@ -1,0 +1,42 @@
+package zio.metrics.connectors.micrometer.internal
+
+import java.lang.{Double => JDouble}
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * Scala's `Double` implementation does not play nicely with Java's
+ * `AtomicReference.compareAndSwap` as `compareAndSwap` uses Java's `==`
+ * reference equality when it performs an equality check. This means that even
+ * if two Scala `Double`s have the same value, they will still fail
+ * `compareAndSwap` as they will most likely be two, distinct object
+ * references. Thus, `compareAndSwap` will fail.
+ *
+ * This `AtomicDouble` implementation is a workaround for this issue that is
+ * backed by an `AtomicLong` instead of an `AtomicReference` in which the
+ * Double's bits are stored as a Long value. This approach also reduces boxing
+ * and unboxing overhead that can be incurred with `AtomicReference`.
+ */
+final private[micrometer] class AtomicDouble private (private val ref: AtomicLong) extends AnyVal {
+
+  def get(): Double =
+    JDouble.longBitsToDouble(ref.get())
+
+  def set(newValue: Double): Unit =
+    ref.set(JDouble.doubleToLongBits(newValue))
+
+  def compareAndSet(expected: Double, newValue: Double): Boolean =
+    ref.compareAndSet(JDouble.doubleToLongBits(expected), JDouble.doubleToLongBits(newValue))
+
+  def incrementBy(value: Double): Unit = {
+    var loop = true
+
+    while (loop) {
+      val current = get()
+      loop = !compareAndSet(current, current + value)
+    }
+  }
+}
+private[micrometer] object AtomicDouble {
+  def make(value: Double): AtomicDouble =
+    new AtomicDouble(new AtomicLong(JDouble.doubleToLongBits(value)))
+}

--- a/micrometer/src/main/scala/zio/metrics/connectors/micrometer/package.scala
+++ b/micrometer/src/main/scala/zio/metrics/connectors/micrometer/package.scala
@@ -9,7 +9,7 @@ import io.micrometer.core.instrument.{MeterRegistry, Tag}
 
 package object micrometer {
 
-  val micrometerLayer: ZLayer[MeterRegistry with MicroMeterConfig, Nothing, Unit] =
+  lazy val micrometerLayer: ZLayer[MeterRegistry with MicrometerConfig, Nothing, Unit] =
     ZLayer.scoped(
       for {
         micrometerMetricListener <- MicrometerMetricListener.make

--- a/micrometer/src/main/scala/zio/metrics/connectors/micrometer/package.scala
+++ b/micrometer/src/main/scala/zio/metrics/connectors/micrometer/package.scala
@@ -9,7 +9,7 @@ import io.micrometer.core.instrument.{MeterRegistry, Tag}
 
 package object micrometer {
 
-  lazy val micrometerLayer: ZLayer[MeterRegistry, Nothing, Unit] =
+  val micrometerLayer: ZLayer[MeterRegistry with MicroMeterConfig, Nothing, Unit] =
     ZLayer.scoped(
       for {
         micrometerMetricListener <- MicrometerMetricListener.make
@@ -23,5 +23,4 @@ package object micrometer {
 
   private[micrometer] def micrometerTags(zioMetricTags: Iterable[MetricLabel]): Iterable[Tag] =
     zioMetricTags.map(metricTag => Tag.of(metricTag.key, metricTag.value))
-
 }

--- a/micrometer/src/test/scala/sample/SampleApp.scala
+++ b/micrometer/src/test/scala/sample/SampleApp.scala
@@ -7,7 +7,7 @@ import zio.http._
 import zio.http.html._
 import zio.http.model.{Headers, Method}
 import zio.metrics.connectors.micrometer
-import zio.metrics.connectors.micrometer.MicroMeterConfig
+import zio.metrics.connectors.micrometer.MicrometerConfig
 import zio.metrics.jvm.DefaultJvmMetrics
 import zio.sample.InstrumentedSample
 
@@ -55,7 +55,7 @@ object SampleApp extends ZIOAppDefault with InstrumentedSample {
       serverConfig,
       Server.live,
       ZLayer.succeed(new PrometheusMeterRegistry(PrometheusConfig.DEFAULT)),
-      ZLayer.succeed(MicroMeterConfig.default),
+      ZLayer.succeed(MicrometerConfig.default),
       micrometer.micrometerLayer,
       Runtime.enableRuntimeMetrics,
       DefaultJvmMetrics.live.unit,

--- a/micrometer/src/test/scala/sample/SampleApp.scala
+++ b/micrometer/src/test/scala/sample/SampleApp.scala
@@ -7,6 +7,7 @@ import zio.http._
 import zio.http.html._
 import zio.http.model.{Headers, Method}
 import zio.metrics.connectors.micrometer
+import zio.metrics.connectors.micrometer.MicroMeterConfig
 import zio.metrics.jvm.DefaultJvmMetrics
 import zio.sample.InstrumentedSample
 
@@ -54,6 +55,7 @@ object SampleApp extends ZIOAppDefault with InstrumentedSample {
       serverConfig,
       Server.live,
       ZLayer.succeed(new PrometheusMeterRegistry(PrometheusConfig.DEFAULT)),
+      ZLayer.succeed(MicroMeterConfig.default),
       micrometer.micrometerLayer,
       Runtime.enableRuntimeMetrics,
       DefaultJvmMetrics.live.unit,

--- a/micrometer/src/test/scala/zio/metrics/connectors/micrometer/MicrometerMetricsSpec.scala
+++ b/micrometer/src/test/scala/zio/metrics/connectors/micrometer/MicrometerMetricsSpec.scala
@@ -24,7 +24,7 @@ object MicrometerMetricsSpec extends ZIOSpecDefault {
   ).provide(
     micrometerLayer,
     ZLayer.succeed(new SimpleMeterRegistry()),
-    ZLayer.succeed(MicroMeterConfig.default),
+    ZLayer.succeed(MicrometerConfig.default),
   ) @@ timed @@ timeoutWarning(60.seconds)
 
   private def testMetric[Type <: MetricKeyType](

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -4,7 +4,7 @@ object Version {
   val Scala213   = "2.13.10"
   val ScalaDotty = "3.2.1"
 
-  val zio     = "2.0.13"
+  val zio     = "2.0.14"
   val zioJson = "0.3.0"
   val zioHttp = "0.0.3"
 


### PR DESCRIPTION
Hey @Grryum thank you for your excellent work on integrating micrometer with zio-metrics-connectors
I managed to take a look and did some slight re-organization of the code inside MicrometerMetricListener and also introduced MicroMeterConfig so we didn't have to hardcode the summary percentile digits. I also made AtomicDouble a value class to see if we can further drop overhead. I have also gone ahead and fixed cross compilation issues that were causing the original PR to fail. Hope you don't mind 😺 